### PR TITLE
plugin_mono: Avoid infinite loop in `UploadNewPkgInstallerPath`

### DIFF
--- a/plugin_mono/source/lib.cc
+++ b/plugin_mono/source/lib.cc
@@ -164,27 +164,29 @@ static int sceKernelLoadStartModuleInternalForMono_Hook(const char* param_1, voi
     const int md = sceKernelLoadStartModuleInternalForMono_original.ptr(param_1, param_2, param_3, param_4, param_5, param_6);
     debug_printf("path %s load returned 0x%08x\n", param_1, md);
     static bool test = false;
+    static int app_exe_h = 0;
     if (!test && md > 0 && strstr(param_1, "/app0/psm/Application/app.exe.sprx"))
     {
+        app_exe_h = md;
         RunPost(md);
         test = true;
     }
     else if (test)
     {
-        static bool once = false;
-        if (!once)
+        if (app_exe_h > 0)
         {
+            static bool once = false;
             if (!Root_Domain)
             {
                 Root_Domain = mono_get_root_domain();
             }
-            if (Root_Domain)
+            else if (!once && Root_Domain && !App_Exe)
             {
                 App_Exe = mono_get_image("/app0/psm/Application/app.exe");
                 if (App_Exe)
                 {
                     ffinal_printf("app_exe: 0x%p\n", App_Exe);
-                    UploadNewPkgInstallerPath(App_Exe);
+                    UploadNewPkgInstallerPath(App_Exe, app_exe_h);
                     UploadOnBranch(App_Exe);
                     once = true;
                 }

--- a/plugin_mono/source/shellui_patch/debug_settings.c
+++ b/plugin_mono/source/shellui_patch/debug_settings.c
@@ -139,7 +139,7 @@ static void* pkg_new_element_ex(void* inst, MonoString* path)
     return ret;
 }
 
-void UploadNewPkgInstallerPath(void* app_exe)
+void UploadNewPkgInstallerPath(void* app_exe, int app_exe_h)
 {
     const uintptr_t SearchDir = (uintptr_t)Mono_Get_Address_of_Method(app_exe, "Sce.Vsh.ShellUI.Settings.PkgInstaller", "SearchJob", "SearchDir", 2);
     if (SearchDir)
@@ -154,7 +154,6 @@ void UploadNewPkgInstallerPath(void* app_exe)
         }
     }
     const uintptr_t pkg_new_element = (uintptr_t)Mono_Get_Address_of_Method(app_exe, "Sce.Vsh.ShellUI.Settings.PkgInstaller", "PageDefault", "NewElementData", 1);
-    const int app_exe_h = sceKernelLoadStartModule("/app0/psm/Application/app.exe.sprx", 0, 0, 0, 0, 0);
     if (pkg_new_element && app_exe_h > 0)
     {
         struct OrbisKernelModuleInfo info = {0};

--- a/plugin_mono/source/shellui_patch/debug_settings.h
+++ b/plugin_mono/source/shellui_patch/debug_settings.h
@@ -3,6 +3,6 @@
 #include <orbis/libkernel.h>
 
 void UploadDebugSettingsPatch(void);
-void UploadNewPkgInstallerPath(void* app_exe);
+void UploadNewPkgInstallerPath(void* app_exe, int app_exe_h);
 void UploadBgftFixup(const struct OrbisKernelModuleInfo* info);
 void UploadShellUICheck(void);


### PR DESCRIPTION
Pass along its handle to not try to load (obtain) the module again

Fixes #22 